### PR TITLE
comment out Enable::GLOBAL_RECO

### DIFF
--- a/macros/Fun4All_G4_EICDetector.C
+++ b/macros/Fun4All_G4_EICDetector.C
@@ -274,7 +274,7 @@ int Fun4All_G4_EICDetector(
   //  Enable::PLUGDOOR = true;
 
   // Other options
-  Enable::GLOBAL_RECO = true;
+  // Enable::GLOBAL_RECO = true;
   Enable::GLOBAL_FASTSIM = true;
 
   Enable::CALOTRIGGER = true && Enable::CEMC_TOWER && Enable::HCALIN_TOWER && Enable::HCALOUT_TOWER;


### PR DESCRIPTION
This commit takes care of the 
ClusterJetInput::get_input - Fatal Error - GlobalVertexMap node is empty. Please turn on the do_bbc or tracking reco flags in the main macro in order to reconstruct the global vertex.
messages