### PR TITLE
Add macro access

### DIFF
--- a/macros/LoopEval.C
+++ b/macros/LoopEval.C
@@ -1,0 +1,47 @@
+#include <eicqa_modules/EvalRootTTree.h>
+#include <eicqa_modules/EvalHit.h>
+
+R__LOAD_LIBRARY(libeicqa_modules.so)
+
+void LoopEval(const std::string &filename)
+{
+  TFile *f1 = new TFile(filename.c_str(),"READ"); //change the input evaluator root file here
+  
+  TTree* T = (TTree*)f1->Get("T");
+  EvalRootTTree *evaltree = nullptr;
+  
+ 
+  T->SetBranchAddress("DST#EvalTTree_HCALOUT",&evaltree);
+  for(int i=0; i<T->GetEntries(); i++)
+  {
+    T->GetEntry(i);
+    cout << "Number of Hits: " << evaltree->get_nhits() << endl;
+    for (int i=0; i<evaltree->get_nhits(); i++)
+    {
+      EvalHit *hit = evaltree->get_hit(i);
+      if (hit)
+      {
+//	cout << "xin: " << hit->get_xin() << endl;
+      }
+    }
+    cout << "Number of towers: " << evaltree->get_ntowers() << endl;
+    for (int i=0; i<evaltree->get_ntowers(); i++)
+    {
+      EvalTower *twr = evaltree->get_tower(i);
+      if (twr)
+      {
+//	cout << "tz: " << twr->get_tz() << endl;
+      }
+    }
+    cout << "Number of clusters: " << evaltree->get_nclusters() << endl;
+    for (int i=0; i<evaltree->get_nclusters(); i++)
+    {
+      EvalCluster *clus = evaltree->get_cluster(i);
+      if (clus)
+      {
+//	cout << "cphi: " << clus->get_cphi() << endl;
+      }
+    }
+    // cout << "ce: " << ce[0] << endl;
+  }
+}

--- a/macros/RunEval.C
+++ b/macros/RunEval.C
@@ -17,6 +17,8 @@ void RunEval(const std::string &detector, const std::string &fname, const int ne
   Fun4AllServer *se = Fun4AllServer::instance();
   EvalRootTTreeReco *eval = new EvalRootTTreeReco();
   eval->Detector(detector);
+// uncomment if you want to drop storing of hits to save space
+//  eval->DropHits();
   se->registerSubsystem(eval);
   Fun4AllInputManager *in = new Fun4AllDstInputManager("QAin");
   in->fileopen(fname);

--- a/source/EvalCluster.h
+++ b/source/EvalCluster.h
@@ -10,20 +10,34 @@ class RawCluster;
 class EvalCluster : public PHObject
 {
  public:
-// ctor with no args to make root happy
+  // ctor with no args to make root happy
   EvalCluster() {}
   EvalCluster(const RawCluster *twr);
   virtual ~EvalCluster() {}
 
   void set_ctowers(const int i) { ctowers = i; }
+  int get_ctowers() const { return ctowers; }
 
   void set_ce(const float f) { ce = f; }
+  float get_ce() const { return ce; }
+
   void set_ceta(const float f) { ceta = f; }
+  float get_ceta() const { return ceta; }
+
   void set_cphi(const float f) { cphi = f; }
+  float get_cphi() const { return cphi; }
+
   void set_ctheta(const float f) { ctheta = f; }
+  float get_ctheta() const { return ctheta; }
+
   void set_cx(const float f) { cx = f; }
+  float get_cx() const { return cx; }
+
   void set_cy(const float f) { cy = f; }
+  float get_cy() const { return cy; }
+
   void set_cz(const float f) { cz = f; }
+  float get_cz() const { return cz; }
 
  private:
   int ctowers = 0;

--- a/source/EvalCluster.h
+++ b/source/EvalCluster.h
@@ -10,6 +10,8 @@ class RawCluster;
 class EvalCluster : public PHObject
 {
  public:
+// ctor with no args to make root happy
+  EvalCluster() {}
   EvalCluster(const RawCluster *twr);
   virtual ~EvalCluster() {}
 

--- a/source/EvalHit.h
+++ b/source/EvalHit.h
@@ -10,13 +10,30 @@ class PHG4Hit;
 class EvalHit : public PHObject
 {
  public:
-// ctor with no args to make root happ
+  // ctor with no args to make root happ
   EvalHit() {}
 
   EvalHit(const PHG4Hit *g4hit);
   virtual ~EvalHit() {}
 
+  int get_detid() const { return detid; }
+  int get_trackid() const { return trackid; }
+
   float get_xin() const { return xin; }
+  float get_xout() const { return xout; }
+
+  float get_yin() const { return yin; }
+  float get_yout() const { return yout; }
+
+  float get_zin() const { return zin; }
+  float get_zout() const { return zout; }
+
+  float get_tin() const { return tin; }
+  float get_tout() const { return tout; }
+
+  float get_edep() const { return edep; }
+  float get_eion() const { return eion; }
+  float get_light_yield() const { return light_yield; }
 
  private:
   int detid = -9999;

--- a/source/EvalHit.h
+++ b/source/EvalHit.h
@@ -10,18 +10,11 @@ class PHG4Hit;
 class EvalHit : public PHObject
 {
  public:
+// ctor with no args to make root happ
+  EvalHit() {}
+
   EvalHit(const PHG4Hit *g4hit);
   virtual ~EvalHit() {}
-
-  /* void set_trkid(const int i) {trackid = i;} */
-  /* void set_x(const int i, const float f) {x[i] = f;} */
-  /* void set_y(const int i, const float f) {y[i] = f;} */
-  /* void set_z(const int i, const float f) {z[i] = f;} */
-  /* void set_t(const int i, const float f) {t[i] = f;} */
-
-  /* void set_edep(const float f) {edep = f;} */
-  /* void set_eion(const float f) {eion = f;} */
-  /* void set_light_yield(const float f) {light_yield = f;} */
 
   float get_xin() const { return xin; }
 

--- a/source/EvalRootTTree.cc
+++ b/source/EvalRootTTree.cc
@@ -101,7 +101,6 @@ EvalRootTTree::get_tower(const size_t i) const
   return (EvalTower *) SnglTowers->At(i);
 }
 
-
 EvalCluster *
 EvalRootTTree::AddCluster(const RawCluster *clus)
 {
@@ -118,5 +117,5 @@ EvalRootTTree::AddCluster(const RawCluster *clus)
 EvalCluster *
 EvalRootTTree::get_cluster(const size_t i) const
 {
-return (EvalCluster *) SnglClusters->At(i);
+  return (EvalCluster *) SnglClusters->At(i);
 }

--- a/source/EvalRootTTree.cc
+++ b/source/EvalRootTTree.cc
@@ -76,6 +76,12 @@ EvalRootTTree::AddHit(const PHG4Hit *g4hit)
   return (static_cast<EvalHit *>(cl[nextindex]));
 }
 
+EvalHit *
+EvalRootTTree::get_hit(const size_t i) const
+{
+  return (EvalHit *) SnglHits->At(i);
+}
+
 EvalTower *
 EvalRootTTree::AddTower(const RawTower *twr)
 {
@@ -89,6 +95,13 @@ EvalRootTTree::AddTower(const RawTower *twr)
   return (static_cast<EvalTower *>(cl[nextindex]));
 }
 
+EvalTower *
+EvalRootTTree::get_tower(const size_t i) const
+{
+  return (EvalTower *) SnglTowers->At(i);
+}
+
+
 EvalCluster *
 EvalRootTTree::AddCluster(const RawCluster *clus)
 {
@@ -100,4 +113,10 @@ EvalRootTTree::AddCluster(const RawCluster *clus)
   }
   new (cl[nextindex]) EvalCluster(clus);
   return (static_cast<EvalCluster *>(cl[nextindex]));
+}
+
+EvalCluster *
+EvalRootTTree::get_cluster(const size_t i) const
+{
+return (EvalCluster *) SnglClusters->At(i);
 }

--- a/source/EvalRootTTree.h
+++ b/source/EvalRootTTree.h
@@ -23,25 +23,55 @@ class EvalRootTTree : public PHObject
   EvalHit* AddHit(const PHG4Hit* g4hit);
   EvalTower* AddTower(const RawTower* twr);
   EvalCluster* AddCluster(const RawCluster* clus);
+
   void set_event_number(const int i) { event = i; }
+  int get_event_number() const { return event;}
+
   void set_gpid(const int i) { gpid = i; }
+  int get_gpid() const { return gpid;}
 
   void set_gvx(const double v) { gvx = v; }
+  double get_gvx() const { return gvx;}
+
   void set_gvy(const double v) { gvy = v; }
+  double get_gvy() const { return gvy;}
+
   void set_gvz(const double v) { gvz = v; }
+  double get_gvz() const { return gvz;}
 
   void set_gpx(const double p) { gpx = p; }
+  double get_gpx() const { return gpx;}
+
   void set_gpy(const double p) { gpy = p; }
+  double get_gpy() const { return gpy;}
+
   void set_gpz(const double p) { gpz = p; }
+  double get_gpz() const { return gpz ;}
+
   void set_ge(const double p) { ge = p; }
+  double get_ge() const { return ge;}
 
   void set_geta(const double d) { geta = d; }
-  void set_gphi(const double d) { gphi = d; }
-  void set_gtheta(const double d) { gtheta = d; }
+  double get_geta() const { return geta;}
 
+  void set_gphi(const double d) { gphi = d; }
+  double get_gphi() const { return gphi;}
+
+  void set_gtheta(const double d) { gtheta = d; }
+  double get_gtheta() const { return gtheta ;}
+
+// calorimeter hits, get hit class, hit accessors are in hit class
   void set_nhits(const int n) { nhits = n; }
+  int get_nhits() const {return nhits;}
+  EvalHit *get_hit(const size_t i) const;
+
   void set_ntowers(const int n) { ntowers = n; }
+  int get_ntowers() const { return ntowers;}
+  EvalTower* get_tower(const size_t i) const;
+
   void set_nclusters(const int n) { nclusters = n; }
+  int get_nclusters() const { return nclusters;}
+  EvalCluster* get_cluster(const size_t i) const;
 
  private:
   TClonesArray* SnglHits = nullptr;

--- a/source/EvalRootTTree.h
+++ b/source/EvalRootTTree.h
@@ -25,52 +25,52 @@ class EvalRootTTree : public PHObject
   EvalCluster* AddCluster(const RawCluster* clus);
 
   void set_event_number(const int i) { event = i; }
-  int get_event_number() const { return event;}
+  int get_event_number() const { return event; }
 
   void set_gpid(const int i) { gpid = i; }
-  int get_gpid() const { return gpid;}
+  int get_gpid() const { return gpid; }
 
   void set_gvx(const double v) { gvx = v; }
-  double get_gvx() const { return gvx;}
+  double get_gvx() const { return gvx; }
 
   void set_gvy(const double v) { gvy = v; }
-  double get_gvy() const { return gvy;}
+  double get_gvy() const { return gvy; }
 
   void set_gvz(const double v) { gvz = v; }
-  double get_gvz() const { return gvz;}
+  double get_gvz() const { return gvz; }
 
   void set_gpx(const double p) { gpx = p; }
-  double get_gpx() const { return gpx;}
+  double get_gpx() const { return gpx; }
 
   void set_gpy(const double p) { gpy = p; }
-  double get_gpy() const { return gpy;}
+  double get_gpy() const { return gpy; }
 
   void set_gpz(const double p) { gpz = p; }
-  double get_gpz() const { return gpz ;}
+  double get_gpz() const { return gpz; }
 
   void set_ge(const double p) { ge = p; }
-  double get_ge() const { return ge;}
+  double get_ge() const { return ge; }
 
   void set_geta(const double d) { geta = d; }
-  double get_geta() const { return geta;}
+  double get_geta() const { return geta; }
 
   void set_gphi(const double d) { gphi = d; }
-  double get_gphi() const { return gphi;}
+  double get_gphi() const { return gphi; }
 
   void set_gtheta(const double d) { gtheta = d; }
-  double get_gtheta() const { return gtheta ;}
+  double get_gtheta() const { return gtheta; }
 
-// calorimeter hits, get hit class, hit accessors are in hit class
+  // calorimeter hits, get hit class, hit accessors are in hit class
   void set_nhits(const int n) { nhits = n; }
-  int get_nhits() const {return nhits;}
-  EvalHit *get_hit(const size_t i) const;
+  int get_nhits() const { return nhits; }
+  EvalHit* get_hit(const size_t i) const;
 
   void set_ntowers(const int n) { ntowers = n; }
-  int get_ntowers() const { return ntowers;}
+  int get_ntowers() const { return ntowers; }
   EvalTower* get_tower(const size_t i) const;
 
   void set_nclusters(const int n) { nclusters = n; }
-  int get_nclusters() const { return nclusters;}
+  int get_nclusters() const { return nclusters; }
   EvalCluster* get_cluster(const size_t i) const;
 
  private:

--- a/source/EvalRootTTreeReco.cc
+++ b/source/EvalRootTTreeReco.cc
@@ -111,7 +111,7 @@ int EvalRootTTreeReco::process_event(PHCompositeNode *topNode)
   // add hits
   PHG4HitContainer *g4hits = findNode::getClass<PHG4HitContainer>(topNode, m_HitNodeName);
 
-  if (g4hits)
+  if (g4hits && !m_DropHitsFlag)
   {
     evaltree->set_nhits(g4hits->size());
     PHG4HitContainer::ConstRange hit_range = g4hits->getHits();

--- a/source/EvalRootTTreeReco.h
+++ b/source/EvalRootTTreeReco.h
@@ -51,7 +51,11 @@ class EvalRootTTreeReco : public SubsysReco
 
   void Detector(const std::string &name);
 
+  void DropHits(const bool drp = true) { m_DropHitsFlag = drp; }
+
  private:
+  bool m_DropHitsFlag = false;
+
   std::string m_Detector;
 
   std::string m_OutputNode;

--- a/source/EvalTower.h
+++ b/source/EvalTower.h
@@ -10,6 +10,8 @@ class RawTower;
 class EvalTower : public PHObject
 {
  public:
+// ctor with no args to make root happy
+  EvalTower() {}
   EvalTower(const RawTower *twr);
   virtual ~EvalTower() {}
 

--- a/source/EvalTower.h
+++ b/source/EvalTower.h
@@ -10,19 +10,34 @@ class RawTower;
 class EvalTower : public PHObject
 {
  public:
-// ctor with no args to make root happy
+  // ctor with no args to make root happy
   EvalTower() {}
   EvalTower(const RawTower *twr);
   virtual ~EvalTower() {}
 
   void set_te(const float f) { te = f; }
+  float get_te() const { return te; }
+
   void set_teta(const float f) { teta = f; }
+  float get_teta() const { return teta; }
+
   void set_tt(const float f) { tt = f; }
+  float get_tt() const { return tt; }
+
   void set_ttheta(const float f) { ttheta = f; }
+  float get_ttheta() const { return ttheta; }
+
   void set_tphi(const float f) { tphi = f; }
+  float get_tphi() const { return tphi; }
+
   void set_tx(const float f) { tx = f; }
+  float get_tx() const { return tx; }
+
   void set_ty(const float f) { ty = f; }
+  float get_ty() const { return ty; }
+
   void set_tz(const float f) { tz = f; }
+  float get_tz() const { return tz; }
 
  private:
   float te = NAN;

--- a/source/Makefile.am
+++ b/source/Makefile.am
@@ -18,8 +18,11 @@ libeicqa_modules_la_LIBADD = \
   -lqa_modules
 
 pkginclude_HEADERS = \
+  EvalCluster.h \
+  EvalHit.h \
   EvalRootTTree.h \
   EvalRootTTreeReco.h \
+  EvalTower.h \
   QAExample.h \
   QAG4SimulationEicCalorimeter.h \
   QAG4SimulationEicCalorimeterSum.h


### PR DESCRIPTION
This PR adds accessors to the classes in the eval ttree so one can pull the values out in a macro. Added DropHits() in the evaluator, suppresses storing of hits to reduce filesize, add example macro which loops over the eval ttree