### PR TITLE
Use 0.1-30GeV/c momentum

### DIFF
--- a/macros/Fun4All_G4_EICDetector.C
+++ b/macros/Fun4All_G4_EICDetector.C
@@ -127,9 +127,9 @@ int Fun4All_G4_EICDetector(
       INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_mean(0., 0., 0.);
       INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_width(0., 0., 0.);
     }
-    INPUTGENERATOR::SimpleEventGenerator[0]->set_eta_range(1.5, 4);
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_eta_range(-4, 4);
     INPUTGENERATOR::SimpleEventGenerator[0]->set_phi_range(-M_PI, M_PI);
-    INPUTGENERATOR::SimpleEventGenerator[0]->set_pt_range(4., 4.);
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_p_range(0.1, 30.);
   }
   // Upsilons
   if (Input::UPSILON)

--- a/macros/RunEval.C
+++ b/macros/RunEval.C
@@ -17,8 +17,7 @@ void RunEval(const std::string &detector, const std::string &fname, const int ne
   Fun4AllServer *se = Fun4AllServer::instance();
   EvalRootTTreeReco *eval = new EvalRootTTreeReco();
   eval->Detector(detector);
-// uncomment if you want to drop storing of hits to save space
-//  eval->DropHits();
+  eval->DropHits(); // comment if you want to store hits (takes a lot of space)
   se->registerSubsystem(eval);
   Fun4AllInputManager *in = new Fun4AllDstInputManager("QAin");
   in->fileopen(fname);


### PR DESCRIPTION
This PR adds the promised update for the Fun4All_G4_EICDetector.C macro. The momentum range is now 0.1-30GeV/c (below 100MeV/c the particles likely won't make it into the detector). The eta range is now +-4