### PR TITLE
increment version number in ClassDef to avoid streamer warnings

### DIFF
--- a/source/EvalRootTTree.h
+++ b/source/EvalRootTTree.h
@@ -106,7 +106,7 @@ class EvalRootTTree : public PHObject
   double gphi = NAN;
   double gtheta = NAN;
 
-  ClassDef(EvalRootTTree, 1)
+  ClassDef(EvalRootTTree, 2)
 };
 
 #endif


### PR DESCRIPTION
This PR takes care of these streamer warnings:
Warning in <TStreamerInfo::BuildCheck>: 
   The StreamerInfo for version 1 of class EvalRootTTree read from the file ../Eval_HCALIN.root
   has a different checksum than the previously loaded StreamerInfo.
   Reading objects of type EvalRootTTree from the file ../Eval_HCALIN.root 
   (and potentially other files) might not work correctly.
   Most likely the version number of the class was not properly
   updated [See ClassDef(EvalRootTTree,1)].

I did add 3 new variables and forgot to update the version number so old ttrees can be read without this warning. This PR should take care of this