### PR TITLE
comment out DIRC which is responsible for huge memry allocation

### DIFF
--- a/macros/DisplayOn.C
+++ b/macros/DisplayOn.C
@@ -60,5 +60,7 @@ void displaycmd()
   cout << " g4->ApplyCommand(\"/vis/ogl/printEPS\")" << endl;
   cout << "set background color:" << endl;
   cout << " g4->ApplyCommand(\"/vis/viewer/set/background white\")" << endl;
+  cout << "Overlap check:" << endl;
+  cout << " g4->ApplyCommand(\"/geometry/test/run\")" << endl;
 }
 #endif

--- a/macros/Fun4All_G4_EICDetector.C
+++ b/macros/Fun4All_G4_EICDetector.C
@@ -247,7 +247,9 @@ int Fun4All_G4_EICDetector(
   G4HCALOUT::TowerDigi = RawTowerDigitizer::kNo_digitization;
 
   // EICDetector geometry - barrel
-  Enable::DIRC = true;
+// DIRC occasionally produces lots of photons which allocates tons of memory
+// which we cannot handle right now, needs fixing
+//  Enable::DIRC = true; 
 
   // EICDetector geometry - 'hadron' direction
   Enable::RICH = true;


### PR DESCRIPTION
This PR comments out the DIRC from the Fun4All macro. It occasionally produces large numbers of photons which allocate tons of memory. Without the DIRC I can run thousand of events with the memory staying at 3.4GB